### PR TITLE
Fix Linear Regression p-values

### DIFF
--- a/gnocchi-cli/src/main/scala/net/fnothaft/gnocchi/cli/RegressPhenotypes.scala
+++ b/gnocchi-cli/src/main/scala/net/fnothaft/gnocchi/cli/RegressPhenotypes.scala
@@ -126,9 +126,6 @@ class RegressPhenotypes(protected val args: RegressPhenotypesArgs) extends BDGSp
     val sqlContext = SQLContext.getOrCreate(sc)
     import sqlContext.implicits._
 
-    val a = args.ploidy
-    println(s"\n\n\n\n\n\n ploidy: $a \n\n\n\n\n\n\n\n")
-
     val absAssociationPath = new File(args.associations).getAbsolutePath
     var parquetInputDestination = absAssociationPath.split("/").reverse.drop(1).reverse.mkString("/")
     parquetInputDestination = parquetInputDestination + "/parquetInputFiles/"
@@ -236,6 +233,7 @@ class RegressPhenotypes(protected val args: RegressPhenotypesArgs) extends BDGSp
       genotypeStates("sampleId"),
       genotypeStates("genotypeState"),
       genotypeStates("missingGenotypes"))
+    println(genoStatesWithNames.take(10).toList)
 
     /*
     For now, just going to use PLINK's Filtering functionality to create already-filtered vcfs from the BED.
@@ -261,11 +259,6 @@ class RegressPhenotypes(protected val args: RegressPhenotypesArgs) extends BDGSp
     val mindDF = sqlContext.sql("SELECT sampleId FROM genotypeStates GROUP BY sampleId HAVING SUM(missingGenotypes)/(COUNT(sampleId)*2) <= %s".format(args.mind))
     // TODO: Resolve with "IN" sql command once spark2.0 is integrated
     val filteredGenotypeStates = genoStatesWithNames.filter(($"sampleId").isin(mindDF.collect().map(r => r(0)): _*))
-    val postFilter = filteredGenotypeStates.as[GenotypeState].rdd.take(10).toList
-    println("\n\n\n\n\n\n")
-    println(postFilter)
-    println("\n\n\n\n\n\n")
-
     filteredGenotypeStates.as[GenotypeState]
   }
 
@@ -295,8 +288,6 @@ class RegressPhenotypes(protected val args: RegressPhenotypesArgs) extends BDGSp
     } else {
       phenotypes = LoadPhenotypesWithoutCovariates(args.oneTwo, args.phenotypes, args.phenoName, sc)
     }
-    println(phenotypes.take(10).toList.map(_.value.toList))
-    println("\n\n\n\n\n\n\n\n")
     phenotypes
   }
 

--- a/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/LinearSiteRegression.scala
+++ b/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/LinearSiteRegression.scala
@@ -17,8 +17,9 @@ package net.fnothaft.gnocchi.association
 
 import net.fnothaft.gnocchi.models.Association
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+import org.apache.commons.math3.linear.SingularMatrixException
 import org.bdgenomics.adam.models.ReferenceRegion
-import scala.math.log10
+import scala.math.{ log10, min }
 import org.apache.commons.math3.distribution.TDistribution
 import org.bdgenomics.formats.avro.{ Contig, Variant }
 
@@ -26,7 +27,7 @@ trait LinearSiteRegression extends SiteRegression {
 
   /**
    * This method will perform linear regression on a single site.
-   * @param observations An array containing tuples in which the first element is the coded genotype. The second is an Array[Double] representing the phenotypes, where the first element in the array is the phenotype to regress and the rest are to be treated as covariates. .
+   * @param observations An array containing tuples in which the first element is the coded genotype. The second is an Array[Double] representing the phenotypes, where the first element in the array is the phenotype to regress and the rest are to be treated as covariates.
    * @param variant The variant that is being regressed.
    * @param phenotype The name of the phenotype being regressed.
    * @return The Association object that results from the linear regression
@@ -55,54 +56,52 @@ trait LinearSiteRegression extends SiteRegression {
       y(i) = observations(i)._2(0)
     }
 
-    println("\n\n\n\n")
-    println(x.map(_.toList).toList)
-    println(y.toList)
-    println("\n\n\n\n")
+    try {
+      // create linear model
+      val ols = new OLSMultipleLinearRegression()
 
-    // create linear model
-    val ols = new OLSMultipleLinearRegression()
+      // input sample data
+      ols.newSampleData(y, x)
 
-    // input sample data 
-    ols.newSampleData(y, x)
+      // calculate coefficients
+      val beta = ols.estimateRegressionParameters()
 
-    // calculate coefficients
-    val beta = ols.estimateRegressionParameters()
+      // calculate Rsquared
+      val rSquared = ols.calculateRSquared()
 
-    // calculate Rsquared
-    val rSquared = ols.calculateRSquared()
+      // compute the regression parameters standard errors
+      val standardErrors = ols.estimateRegressionParametersStandardErrors()
 
-    // compute the regression parameters standard errors
-    val standardErrors = ols.estimateRegressionParametersStandardErrors()
+      // get standard error for genotype parameter (for p value calculation)
+      val genoSE = standardErrors(1)
 
-    // get standard error for genotype parameter (for p value calculation)
-    val genoSE = standardErrors(1)
+      // test statistic t for jth parameter is equal to bj/SEbj, the parameter estimate divided by its standard error
+      val t = beta(1) / genoSE
 
-    // test statistic t for jth parameter is equal to bj/SEbj, the parameter estimate divided by its standard error
-    val t = beta(1) / genoSE
+      /* calculate p-value and report:
+        Under null hypothesis (i.e. the j'th element of weight vector is 0) the relevant distribution is
+        a t-distribution with N-p degrees of freedom. (N = number of samples, p = number of regressors i.e. genotype+covariates
+        https://en.wikipedia.org/wiki/T-statistic
+      */
+      val tDist = new TDistribution(numObservations - 2)
+      val pvalue = 2 * tDist.cumulativeProbability(-math.abs(t))
+      val logPValue = log10(pvalue)
 
-    /* calculate p-value and report: 
-      Under null hypothesis (i.e. the j'th element of weight vector is 0) the relevant distribution is 
-      a t-distribution with N-p-1 degrees of freedom.
-    */
-    val tDist = new TDistribution(numObservations - observationLength - 1)
-    val pvalue = 1.0 - tDist.cumulativeProbability(t)
-    val logPValue = log10(pvalue)
-
-    // pack up the information into an Association object
-    //    val variant = new Variant()
-    //    val contig = new Contig()
-    //    contig.setContigName(locus.referenceName)
-    //    variant.setContig(contig)
-    //    variant.setStart(locus.start)
-    //    variant.setEnd(locus.end)
-    //    variant.setAlternateAllele(altAllele)
-    val statistics = Map("rSquared" -> rSquared,
-      "weights" -> beta,
-      "intercept" -> beta(0))
-    val associationObject = new Association(variant, phenotype, logPValue, statistics)
-
-    return associationObject
+      // pack up the information into an Association object
+      //    val variant = new Variant()
+      //    val contig = new Contig()
+      //    contig.setContigName(locus.referenceName)
+      //    variant.setContig(contig)
+      //    variant.setStart(locus.start)
+      //    variant.setEnd(locus.end)
+      //    variant.setAlternateAllele(altAllele)
+      val statistics = Map("rSquared" -> rSquared,
+        "weights" -> beta,
+        "intercept" -> beta(0))
+      Association(variant, phenotype, logPValue, statistics)
+    } catch {
+      case error: org.apache.commons.math3.linear.SingularMatrixException => Association(variant, phenotype, 0.0, Map())
+    }
   }
 }
 

--- a/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/LinearSiteRegression.scala
+++ b/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/LinearSiteRegression.scala
@@ -78,10 +78,10 @@ trait LinearSiteRegression extends SiteRegression {
 
       /* calculate p-value and report:
         Under null hypothesis (i.e. the j'th element of weight vector is 0) the relevant distribution is
-        a t-distribution with N-p degrees of freedom. (N = number of samples, p = number of regressors i.e. genotype+covariates
+        a t-distribution with N-p-1 degrees of freedom. (N = number of samples, p = number of regressors i.e. genotype+covariates+intercept)
         https://en.wikipedia.org/wiki/T-statistic
       */
-      val tDist = new TDistribution(numObservations - 2)
+      val tDist = new TDistribution(numObservations - observationLength - 1)
       val pvalue = 2 * tDist.cumulativeProbability(-math.abs(t))
       val logPValue = log10(pvalue)
 

--- a/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/SiteRegression.scala
+++ b/gnocchi-core/src/main/scala/net/fnothaft/gnocchi/association/SiteRegression.scala
@@ -32,7 +32,7 @@ trait SiteRegression extends Serializable {
   */
   final def apply[T](rdd: RDD[GenotypeState],
                      phenotypes: RDD[Phenotype[T]]): RDD[Association] = {
-    val temp = rdd.keyBy(_.sampleId)
+    rdd.keyBy(_.sampleId)
       // join together the samples with both genotype and phenotype entry
       .join(phenotypes.keyBy(_.sampleId))
       .map(kvv => {
@@ -53,19 +53,6 @@ trait SiteRegression extends Serializable {
         variant.setAlternateAllele(gs.alt)
         ((variant, pheno.phenotype), p)
       }).groupByKey()
-    val temp2 = temp
-      .map(site => {
-        val ((variant, pheno), observations) = site
-        // build array to regress on, and then regress
-        ((variant, pheno), observations.map(p => {
-          // unpack p
-          val (genotypeState, phenotype) = p
-          // return genotype and phenotype in the correct form
-          (clipOrKeepState(genotypeState), phenotype.toDouble.toList)
-        }).toList)
-      })
-    println(temp2.take(10).toList mkString "\n")
-    temp
       .map(site => {
         val ((variant, pheno), observations) = site
         // build array to regress on, and then regress
@@ -76,7 +63,6 @@ trait SiteRegression extends Serializable {
           (clipOrKeepState(genotypeState), phenotype.toDouble)
         }).toArray, variant, pheno)
       })
-
   }
 
   /**

--- a/gnocchi-core/src/test/scala/net/fnothaft/gnocchi/association/LinearSiteRegressionSuite.scala
+++ b/gnocchi-core/src/test/scala/net/fnothaft/gnocchi/association/LinearSiteRegressionSuite.scala
@@ -285,6 +285,8 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.2954)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.2944)
 
+    println(regressionResult.statistics("weights").asInstanceOf[Array[Double]].toList)
+
     // check that the p-value for Brain is correct (expectedPVal ~= 0.000855632)
     val expectedLogPVal = -3.06771
     assert(regressionResult.logPValue <= expectedLogPVal + 0.005)

--- a/gnocchi-core/src/test/scala/net/fnothaft/gnocchi/association/LinearSiteRegressionSuite.scala
+++ b/gnocchi-core/src/test/scala/net/fnothaft/gnocchi/association/LinearSiteRegressionSuite.scala
@@ -16,9 +16,6 @@
 package net.fnothaft.gnocchi.association
 
 import net.fnothaft.gnocchi.GnocchiFunSuite
-import net.fnothaft.gnocchi.models.{ Association, GenotypeState }
-import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
-import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.formats.avro.Variant
 
 class LinearSiteRegressionSuite extends GnocchiFunSuite {
@@ -36,13 +33,11 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(7) = (2, Array[Double](3))
     observations(8) = (2, Array[Double](3))
     observations(9) = (2, Array[Double](3))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     //use additiveLinearRegression to regress on Ascombe1
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
     //Assert that the rsquared is in the right threshold. 
     assert(regressionResult.statistics("rSquared") == 1.0, "rSquared = " + regressionResult.statistics("rSquared"))
@@ -85,17 +80,20 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(8) = (12.0, Array[Double](10.84))
     observations(9) = (7.0, Array[Double](4.82))
     observations(10) = (5.0, Array[Double](5.68))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     //use additiveLinearRegression to regress on Ascombe1
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
     //Assert that the rsquared is in the right threshold. 
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.6670)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.6660)
+
+    // Assert that the p-value for independent variable is correct (expectedPVal ~= 0.002169629)
+    val expectedLogPVal = -2.66361455
+    assert(regressionResult.logPValue <= expectedLogPVal + 0.005)
+    assert(regressionResult.logPValue >= expectedLogPVal - 0.005)
   }
 
   test("The rsquared for Ascombe II should be within .001 of expected results 0.6662") {
@@ -113,17 +111,20 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(8) = (12.0, Array[Double](9.13))
     observations(9) = (7.0, Array[Double](7.26))
     observations(10) = (5.0, Array[Double](4.74))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     //use additiveLinearRegression to regress on Ascombe1
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
     //Assert that the rsquared is in the right threshold. 
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.6670)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.6660)
+
+    // Assert that the p-value for independent variable is correct (expectedPVal ~= 0.002178816)
+    val expectedLogPVal = -2.6617794
+    assert(regressionResult.logPValue <= expectedLogPVal + 0.005)
+    assert(regressionResult.logPValue >= expectedLogPVal - 0.005)
   }
 
   test("The rsquared for Ascombe III should be within .001 of expected results 0.6663") {
@@ -141,17 +142,20 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(8) = (12.0, Array[Double](8.15))
     observations(9) = (7.0, Array[Double](6.42))
     observations(10) = (5.0, Array[Double](5.73))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     //use additiveLinearRegression to regress on Ascombe1
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
     //Assert that the rsquared is in the right threshold. 
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.6670)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.6660)
+
+    // Assert that the p-value for independent variable is correct (expectedPVal ~= 0.002176305)
+    val expectedLogPVal = -2.66228018
+    assert(regressionResult.logPValue <= expectedLogPVal + 0.005)
+    assert(regressionResult.logPValue >= expectedLogPVal - 0.005)
   }
 
   test("The rsquared for Ascombe IV should be within .001 of expected results 0.6667") {
@@ -169,17 +173,21 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(8) = (8.0, Array[Double](5.56))
     observations(9) = (8.0, Array[Double](7.91))
     observations(10) = (8.0, Array[Double](6.89))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
+
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     //use additiveLinearRegression to regress on Ascombe1
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
-    //Assert that the rsquared is in the right threshold. 
+    //Assert that the rsquared is in the right threshold.
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.6670)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.6660)
+
+    // Assert that the p-value for independent variable is correct (expectedPVal ~= 0.002164602)
+    val expectedLogPVal = -2.664621875
+    assert(regressionResult.logPValue <= expectedLogPVal + 0.005)
+    assert(regressionResult.logPValue >= expectedLogPVal - 0.005)
   }
 
   test("Test multiple regression on PIQ data") {
@@ -267,21 +275,19 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     observations(35) = (89.40, Array[Double](94, 64.5, 139))
     observations(36) = (93.00, Array[Double](74, 74.0, 148))
     observations(37) = (93.59, Array[Double](89, 75.5, 179))
-    val locus = ReferenceRegion("Name", 1, 2)
-    val altAllele = "C"
     val phenotype = "MyPhenotype"
     val variant = new Variant
 
     // use additiveLinearAssociation to regress on PIQ data
-    var regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
+    val regressionResult = AdditiveLinearAssociation.regressSite(observations, variant, phenotype)
 
     // check that the rsquared value is correct (correct is 0.2949)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] <= 0.2954)
     assert(regressionResult.statistics("rSquared").asInstanceOf[Double] >= 0.2944)
 
-    // check that the p-value for Brain is correct (correct is ~0.001)
-    assert(regressionResult.logPValue <= -2.721)
-    assert(regressionResult.logPValue >= -4.0)
-
+    // check that the p-value for Brain is correct (expectedPVal ~= 0.000855632)
+    val expectedLogPVal = -3.06771
+    assert(regressionResult.logPValue <= expectedLogPVal + 0.005)
+    assert(regressionResult.logPValue >= expectedLogPVal - 0.005)
   }
 }


### PR DESCRIPTION
Reset t-dist degrees of freedom to (N-p-1), convert to two-tailed distribution, and added p-value verification on unit tests with tighter bounds